### PR TITLE
DDCE-3420 pass security headers as part of the stub response

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -45,6 +45,7 @@ play.http.errorHandler = "uk.gov.hmrc.nationalinsurancedesstub.ErrorHandler"
 # Additional play modules can be added here
 play.modules.enabled += "uk.gov.hmrc.mongo.play.PlayMongoModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
+play.filters.enabled += "play.filters.headers.SecurityHeadersFilter"
 
 # Session Timeout
 # ~~~~

--- a/test/it/helpers/BaseSpec.scala
+++ b/test/it/helpers/BaseSpec.scala
@@ -44,7 +44,7 @@ trait BaseSpec
       "run.mode"               -> "It"
     )
     .build()
-  val timeoutInSeconds = 5
+  val timeoutInSeconds                        = 5
   implicit val timeout: FiniteDuration        = Duration(timeoutInSeconds, TimeUnit.SECONDS)
   val serviceUrl                              = s"http://localhost:$port"
 }


### PR DESCRIPTION
National insraunce zap tests are failing cause the response doesn't contain relevant security headers. Adding them as part of this PR

And a minor scalafmt spacing issue fix