### PR TITLE
DDCE-3581: Upgrade to Scala 2.13

### DIFF
--- a/app/uk/gov/hmrc/nationalinsurancedesstub/ErrorHandler.scala
+++ b/app/uk/gov/hmrc/nationalinsurancedesstub/ErrorHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/nationalinsurancedesstub/config/AppContext.scala
+++ b/app/uk/gov/hmrc/nationalinsurancedesstub/config/AppContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/nationalinsurancedesstub/controllers/Binders.scala
+++ b/app/uk/gov/hmrc/nationalinsurancedesstub/controllers/Binders.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/nationalinsurancedesstub/controllers/DocumentationController.scala
+++ b/app/uk/gov/hmrc/nationalinsurancedesstub/controllers/DocumentationController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/nationalinsurancedesstub/controllers/ErrorResponses.scala
+++ b/app/uk/gov/hmrc/nationalinsurancedesstub/controllers/ErrorResponses.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/nationalinsurancedesstub/controllers/NationalInsuranceSummaryController.scala
+++ b/app/uk/gov/hmrc/nationalinsurancedesstub/controllers/NationalInsuranceSummaryController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/nationalinsurancedesstub/models/APIAccess.scala
+++ b/app/uk/gov/hmrc/nationalinsurancedesstub/models/APIAccess.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/nationalinsurancedesstub/models/Errors.scala
+++ b/app/uk/gov/hmrc/nationalinsurancedesstub/models/Errors.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/nationalinsurancedesstub/models/NICs.scala
+++ b/app/uk/gov/hmrc/nationalinsurancedesstub/models/NICs.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/nationalinsurancedesstub/models/NationalInsuranceSummary.scala
+++ b/app/uk/gov/hmrc/nationalinsurancedesstub/models/NationalInsuranceSummary.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/nationalinsurancedesstub/models/Requests.scala
+++ b/app/uk/gov/hmrc/nationalinsurancedesstub/models/Requests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/nationalinsurancedesstub/models/TaxYear.scala
+++ b/app/uk/gov/hmrc/nationalinsurancedesstub/models/TaxYear.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/nationalinsurancedesstub/models/package.scala
+++ b/app/uk/gov/hmrc/nationalinsurancedesstub/models/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/nationalinsurancedesstub/repositories/NationalInsuranceSummaryRepository.scala
+++ b/app/uk/gov/hmrc/nationalinsurancedesstub/repositories/NationalInsuranceSummaryRepository.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/nationalinsurancedesstub/services/NationalInsuranceSummaryService.scala
+++ b/app/uk/gov/hmrc/nationalinsurancedesstub/services/NationalInsuranceSummaryService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/nationalinsurancedesstub/services/ScenarioLoader.scala
+++ b/app/uk/gov/hmrc/nationalinsurancedesstub/services/ScenarioLoader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
 import uk.gov.hmrc.DefaultBuildSettings._
-import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin._
 
 lazy val appName = "national-insurance-des-stub"
 
@@ -8,8 +7,6 @@ def itTestFilter(name: String): Boolean = name startsWith "it"
 
 lazy val microservice = Project(appName, file("."))
   .enablePlugins(PlayScala, SbtDistributablesPlugin)
-  .settings(scalaSettings: _*)
-  .settings(publishingSettings: _*)
   .settings(defaultSettings(): _*)
   .settings(
     scalaVersion := "2.13.10",
@@ -37,7 +34,6 @@ lazy val microservice = Project(appName, file("."))
     addTestReportOption(IntegrationTest, "int-test-reports")
   )
   .settings(
-    // Coverage configuration
     coverageMinimumStmtTotal := 100,
     coverageFailOnMinimum := true,
     coverageExcludedPackages := "<empty>;com.kenshoo.play.metrics.*;.*definition.*;prod.*;testOnlyDoNotUseInAppConf.*;app.*;uk.gov.hmrc.BuildInfo"

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ lazy val microservice = Project(appName, file("."))
   .settings(publishingSettings: _*)
   .settings(defaultSettings(): _*)
   .settings(
-    scalaVersion := "2.12.17",
+    scalaVersion := "2.13.10",
     retrieveManaged := true,
     majorVersion := 0,
     libraryDependencies ++= AppDependencies(),

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,4 +1,4 @@
-# Copyright 2022 HM Revenue & Customs
+# Copyright 2023 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,7 +2,7 @@ import play.core.PlayVersion
 import sbt._
 
 object AppDependencies {
-  private lazy val bootstrapPlayVersion = "7.12.0"
+  private lazy val bootstrapPlayVersion = "7.14.0"
   private lazy val hmrcMongoPlayVersion = "0.74.0"
 
   private lazy val compile: Seq[ModuleID] = Seq(
@@ -11,12 +11,12 @@ object AppDependencies {
     "uk.gov.hmrc"                  %% "play-hmrc-api"             % "7.1.0-play-28",
     "uk.gov.hmrc.mongo"            %% "hmrc-mongo-play-28"        % hmrcMongoPlayVersion,
     "org.scalaj"                   %% "scalaj-http"               % "2.4.2",
-    "com.fasterxml.jackson.module" %% "jackson-module-scala"      % "2.14.1"
+    "com.fasterxml.jackson.module" %% "jackson-module-scala"      % "2.14.2"
   )
 
   private val test: Seq[ModuleID] = Seq(
     "uk.gov.hmrc.mongo"   %% "hmrc-mongo-test-play-28" % hmrcMongoPlayVersion,
-    "org.scalatest"       %% "scalatest"               % "3.2.14",
+    "org.scalatest"       %% "scalatest"               % "3.2.15",
     "uk.gov.hmrc"         %% "bootstrap-test-play-28"  % bootstrapPlayVersion,
     "org.mockito"         %% "mockito-scala-scalatest" % "1.17.12",
     "com.typesafe.play"   %% "play-test"               % PlayVersion.current,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,7 +10,7 @@ ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" 
 addSbtPlugin("uk.gov.hmrc"         % "sbt-auto-build"     % "3.8.0")
 addSbtPlugin("uk.gov.hmrc"         % "sbt-distributables" % "2.1.0")
 addSbtPlugin("com.typesafe.play"   % "sbt-plugin"         % "2.8.18")
-addSbtPlugin("org.scoverage"       % "sbt-scoverage"      % "2.0.6")
+addSbtPlugin("org.scoverage"       % "sbt-scoverage"      % "2.0.7")
 addSbtPlugin("com.beautiful-scala" % "sbt-scalastyle"     % "1.5.1")
 addSbtPlugin("com.timushev.sbt"    % "sbt-updates"        % "0.6.3")
 addSbtPlugin("org.scalameta"       % "sbt-scalafmt"       % "2.5.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,9 +7,9 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
 // Try to remove when sbt 1.8.0+ and scoverage is 2.0.7+
 ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
 
-addSbtPlugin("uk.gov.hmrc"         % "sbt-auto-build"     % "3.8.0")
-addSbtPlugin("uk.gov.hmrc"         % "sbt-distributables" % "2.1.0")
-addSbtPlugin("com.typesafe.play"   % "sbt-plugin"         % "2.8.18")
+addSbtPlugin("uk.gov.hmrc"         % "sbt-auto-build"     % "3.9.0")
+addSbtPlugin("uk.gov.hmrc"         % "sbt-distributables" % "2.2.0")
+addSbtPlugin("com.typesafe.play"   % "sbt-plugin"         % "2.8.19")
 addSbtPlugin("org.scoverage"       % "sbt-scoverage"      % "2.0.7")
 addSbtPlugin("com.beautiful-scala" % "sbt-scalastyle"     % "1.5.1")
 addSbtPlugin("com.timushev.sbt"    % "sbt-updates"        % "0.6.3")

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -9,7 +9,7 @@
  <check level="warning" class="org.scalastyle.file.HeaderMatchesChecker" enabled="true">
   <parameters>
    <parameter name="header"><![CDATA[/*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/common/util/ResourceLoader.scala
+++ b/test/common/util/ResourceLoader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/it/NationalInsuranceSummarySpec.scala
+++ b/test/it/NationalInsuranceSummarySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/it/PlatformIntegrationSpec.scala
+++ b/test/it/PlatformIntegrationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/it/helpers/BaseSpec.scala
+++ b/test/it/helpers/BaseSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/resources/test.application.conf
+++ b/test/resources/test.application.conf
@@ -1,4 +1,4 @@
-# Copyright 2022 HM Revenue & Customs
+# Copyright 2023 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/unit/ErrorHandlerSpec.scala
+++ b/test/unit/ErrorHandlerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/controllers/NationalInsuranceSummaryControllerSpec.scala
+++ b/test/unit/controllers/NationalInsuranceSummaryControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/controllers/TaxYearBinderSpec.scala
+++ b/test/unit/controllers/TaxYearBinderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/controllers/UtrBinderSpec.scala
+++ b/test/unit/controllers/UtrBinderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/models/APIAccessSpec.scala
+++ b/test/unit/models/APIAccessSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/models/TaxYearSpec.scala
+++ b/test/unit/models/TaxYearSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
### DDCE-3581: Upgrade to Scala 2.13

- Updated Scala and dependencies
- Run AT locally
- Also check build-jobs and service-manager-config updates below